### PR TITLE
Add user, auth, and order API tests with mocked repositories

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+import pytest
+from fastapi.testclient import TestClient
+from api.main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app.dependency_overrides.clear()
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()

--- a/api/tests/test_auth_router.py
+++ b/api/tests/test_auth_router.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+from types import SimpleNamespace
+
+import pytest
+
+from api.dependencies import get_db, get_settings
+from api.routers import auth
+
+
+class DummyUser:
+    def __init__(self, user_id: int, username: str, password: str) -> None:
+        self.user_id = user_id
+        self.username = username
+        self.password = password
+
+
+class DummyUserRepo:
+    def __init__(self, users: list[DummyUser]) -> None:
+        self.users = {u.username: u for u in users}
+
+    def get_by_username(self, username: str) -> DummyUser | None:
+        return self.users.get(username)
+
+    def verify_password(self, plain: str, stored: str) -> bool:
+        return plain == stored
+
+
+class DummyTokenRepo:
+    def __init__(self) -> None:
+        self.tokens: dict[int, set[str]] = {}
+
+    def add_refresh_token(self, user_id: int, token: str, expiry: int) -> None:
+        self.tokens.setdefault(user_id, set()).add(token)
+
+    def is_refresh_token_valid(self, user_id: int, token: str) -> bool:
+        return token in self.tokens.get(user_id, set())
+
+    def revoke_refresh_token(self, user_id: int, token: str) -> None:
+        self.tokens.get(user_id, set()).discard(token)
+
+
+@pytest.fixture
+def setup_auth(client, monkeypatch: pytest.MonkeyPatch):
+    user = DummyUser(1, "alice", "pw")
+    user_repo = DummyUserRepo([user])
+    token_repo = DummyTokenRepo()
+
+    monkeypatch.setattr(auth, "UserRepository", lambda db: user_repo)
+    monkeypatch.setattr(auth, "TokenRepository", lambda db: token_repo)
+    monkeypatch.setattr(auth, "create_tokens", lambda uid, settings: ("access", "refresh", 0))
+
+    def fake_verify(token: str, settings) -> dict[str, str]:
+        if token in {"refresh", "old", "ref"}:
+            return {"sub": "1"}
+        raise Exception("bad token")
+
+    monkeypatch.setattr(auth, "verify_token", fake_verify)
+
+    client.app.dependency_overrides[get_db] = lambda: None
+    client.app.dependency_overrides[get_settings] = lambda: SimpleNamespace(access_token_expire_minutes=1)
+    return client, token_repo
+
+
+def test_login_success(setup_auth) -> None:
+    client, token_repo = setup_auth
+    response = client.post("/auth/login", data={"username": "alice", "password": "pw"})
+    assert response.status_code == 200
+    assert response.json()["access_token"] == "access"
+    assert token_repo.is_refresh_token_valid(1, "refresh")
+
+
+def test_login_invalid_credentials(setup_auth) -> None:
+    client, _ = setup_auth
+    response = client.post("/auth/login", data={"username": "alice", "password": "wrong"})
+    assert response.status_code == 401
+
+
+def test_refresh_success(setup_auth, monkeypatch: pytest.MonkeyPatch) -> None:
+    client, token_repo = setup_auth
+    token_repo.add_refresh_token(1, "old", 0)
+    monkeypatch.setattr(auth, "create_tokens", lambda uid, settings: ("new_access", "new_refresh", 0))
+    response = client.post("/auth/refresh", json={"refresh_token": "old"})
+    assert response.status_code == 200
+    assert response.json()["access_token"] == "new_access"
+    assert token_repo.is_refresh_token_valid(1, "new_refresh")
+
+
+def test_refresh_invalid_token(setup_auth, monkeypatch: pytest.MonkeyPatch) -> None:
+    client, _ = setup_auth
+    monkeypatch.setattr(auth, "verify_token", lambda token, settings: (_ for _ in ()).throw(Exception("bad")))
+    response = client.post("/auth/refresh", json={"refresh_token": "bad"})
+    assert response.status_code == 401
+
+
+def test_logout_success(setup_auth) -> None:
+    client, token_repo = setup_auth
+    token_repo.add_refresh_token(1, "ref", 0)
+    response = client.post("/auth/logout", json={"refresh_token": "ref"})
+    assert response.status_code == 200
+    assert not token_repo.is_refresh_token_valid(1, "ref")
+
+
+def test_logout_invalid_token(setup_auth, monkeypatch: pytest.MonkeyPatch) -> None:
+    client, _ = setup_auth
+    monkeypatch.setattr(auth, "verify_token", lambda token, settings: (_ for _ in ()).throw(Exception("bad")))
+    response = client.post("/auth/logout", json={"refresh_token": "bad"})
+    assert response.status_code == 401

--- a/api/tests/test_order_router.py
+++ b/api/tests/test_order_router.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import pytest
+
+from api.dependencies import get_current_user, get_order_repo, get_restaurant_repo
+
+
+class DummyUser:
+    def __init__(self, user_id: int) -> None:
+        self.user_id = user_id
+
+
+class DummyDish:
+    def __init__(self, name: str, description: str, price: float) -> None:
+        self.name = name
+        self.description = description
+        self.price = price
+
+
+class DummyOrderItem:
+    def __init__(self, restaurant_id: int, dish_id: int, quantity: int, dish: DummyDish) -> None:
+        self.restaurant_id = restaurant_id
+        self.dish_id = dish_id
+        self.quantity = quantity
+        self.dish = dish
+
+
+class DummyOrder:
+    def __init__(self, user_id: int, items: list[DummyOrderItem]) -> None:
+        self.user_id = user_id
+        self.status = "open"
+        self.payment_method = "cash"
+        self.created_at = "now"
+        self.items = items
+
+
+class DummyRestaurantRepo:
+    def __init__(self) -> None:
+        self.dishes: dict[tuple[int, int], DummyDish] = {
+            (1, 1): DummyDish("pizza", "cheese", 10.0)
+        }
+
+    def get_dish(self, restaurant_id: int, dish_id: int) -> DummyDish | None:
+        return self.dishes.get((restaurant_id, dish_id))
+
+
+class DummyOrderRepo:
+    def __init__(self, restaurant_repo: DummyRestaurantRepo) -> None:
+        self.restaurant_repo = restaurant_repo
+        self.items: list[DummyOrderItem] = []
+
+    def create_order(self, user: DummyUser) -> None:  # pragma: no cover - simple placeholder
+        self.user_id = user.user_id
+
+    def add_item(
+        self, *, user_id: int, restaurant_id: int, dish_id: int, quantity: int
+    ) -> DummyOrderItem:
+        dish = self.restaurant_repo.get_dish(restaurant_id, dish_id)
+        if not dish:
+            raise ValueError("dish not found")
+        item = DummyOrderItem(restaurant_id, dish_id, quantity, dish)
+        self.items.append(item)
+        return item
+
+    def view_order(self, user_id: int) -> DummyOrder:
+        if not self.items:
+            raise ValueError("no order")
+        return DummyOrder(user_id, self.items)
+
+    def remove_item(self, *, user_id: int, restaurant_id: int, dish_id: int) -> None:
+        for idx, it in enumerate(self.items):
+            if it.restaurant_id == restaurant_id and it.dish_id == dish_id:
+                self.items.pop(idx)
+                return
+        raise ValueError("not found")
+
+
+@pytest.fixture
+def order_setup(client):
+    restaurant_repo = DummyRestaurantRepo()
+    order_repo = DummyOrderRepo(restaurant_repo)
+    user = DummyUser(1)
+    client.app.dependency_overrides[get_current_user] = lambda: user
+    client.app.dependency_overrides[get_order_repo] = lambda: order_repo
+    client.app.dependency_overrides[get_restaurant_repo] = lambda: restaurant_repo
+    return client, order_repo, restaurant_repo, user
+
+
+def test_add_dish_to_order_success(order_setup) -> None:
+    client, _, _, _ = order_setup
+    payload = {"restaurant_id": 1, "dish_id": 1, "quantity": 2}
+    response = client.post("/order/orders/items", json=payload)
+    assert response.status_code == 200
+    assert response.json()["quantity"] == 2
+
+
+def test_add_dish_to_order_dish_not_found(order_setup) -> None:
+    client, _, restaurant_repo, _ = order_setup
+    restaurant_repo.dishes.clear()
+    payload = {"restaurant_id": 1, "dish_id": 2, "quantity": 1}
+    response = client.post("/order/orders/items", json=payload)
+    assert response.status_code == 404
+
+
+def test_view_current_order_success(order_setup) -> None:
+    client, order_repo, _, user = order_setup
+    order_repo.add_item(user_id=user.user_id, restaurant_id=1, dish_id=1, quantity=1)
+    response = client.get("/order/orders/")
+    assert response.status_code == 200
+    assert response.json()["items"][0]["dish_id"] == 1
+
+
+def test_remove_dish_success(order_setup) -> None:
+    client, order_repo, _, user = order_setup
+    order_repo.add_item(user_id=user.user_id, restaurant_id=1, dish_id=1, quantity=1)
+    response = client.delete("/order/orders/items/1/1")
+    assert response.status_code == 204
+    assert order_repo.items == []
+
+
+def test_remove_dish_not_found(order_setup) -> None:
+    client, _, _, _ = order_setup
+    response = client.delete("/order/orders/items/1/1")
+    assert response.status_code == 404

--- a/api/tests/test_user_router.py
+++ b/api/tests/test_user_router.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from fastapi.testclient import TestClient
+import pytest
+
+from api.main import app
+from api.dependencies import get_current_user, get_order_repo, get_user_repo
+
+
+class DummyUser:
+    def __init__(self, user_id: int, name: str, phone: str, address: str, password: str = "pwd") -> None:
+        self.user_id = user_id
+        self.name = name
+        self.phone = phone
+        self.address = address
+        self.password = password
+
+
+class DummyUserRepo:
+    def __init__(self, existing: list[DummyUser] | None = None) -> None:
+        self.users = {u.name: u for u in existing or []}
+
+    def get_by_username(self, username: str) -> DummyUser | None:
+        return self.users.get(username)
+
+    def create_user(self, username: str, password: str, phone: str, address: str) -> DummyUser:
+        user_id = len(self.users) + 1
+        user = DummyUser(user_id, username, phone, address, password)
+        self.users[username] = user
+        return user
+
+    def update_user(self, user: DummyUser, **fields: str | None) -> DummyUser:
+        for attr, val in fields.items():
+            if val is not None:
+                setattr(user, attr, val)
+        return user
+
+    def delete_user(self, user: DummyUser) -> None:
+        self.users.pop(user.name, None)
+
+
+class DummyOrderRepo:
+    def create_order(self, user: DummyUser) -> object:
+        self.created_for = user.user_id
+        return object()
+
+
+@pytest.fixture
+def client_and_repo() -> tuple[TestClient, DummyUserRepo]:
+    user_repo = DummyUserRepo()
+    order_repo = DummyOrderRepo()
+    app.dependency_overrides[get_user_repo] = lambda: user_repo
+    app.dependency_overrides[get_order_repo] = lambda: order_repo
+    with TestClient(app) as client:
+        yield client, user_repo
+    app.dependency_overrides.clear()
+
+
+def test_create_user_success(client_and_repo: tuple[TestClient, DummyUserRepo]) -> None:
+    client, _ = client_and_repo
+    payload = {"name": "alice", "password": "secretpw", "phone": "123", "address": "street"}
+    response = client.post("/user/users/", json=payload)
+    assert response.status_code == 201
+    assert response.json() == {
+        "user_id": 1,
+        "name": "alice",
+        "phone": "123",
+        "address": "street",
+    }
+
+
+def test_create_user_duplicate(client_and_repo: tuple[TestClient, DummyUserRepo]) -> None:
+    client, repo = client_and_repo
+    repo.users["bob"] = DummyUser(1, "bob", "555", "addr")
+    payload = {"name": "bob", "password": "secret", "phone": "123", "address": "addr"}
+    response = client.post("/user/users/", json=payload)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "User with this name already exists"
+
+
+def test_read_own_profile(client_and_repo: tuple[TestClient, DummyUserRepo]) -> None:
+    client, _ = client_and_repo
+    user = DummyUser(1, "carol", "789", "main")
+    client.app.dependency_overrides[get_current_user] = lambda: user
+    response = client.get("/user/users/me")
+    assert response.status_code == 200
+    assert response.json() == {
+        "user_id": 1,
+        "name": "carol",
+        "phone": "789",
+        "address": "main",
+    }
+    client.app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_update_profile(client_and_repo: tuple[TestClient, DummyUserRepo]) -> None:
+    client, _ = client_and_repo
+    user = DummyUser(1, "dave", "111", "old")
+    client.app.dependency_overrides[get_current_user] = lambda: user
+    payload = {"phone": "222", "address": "new"}
+    response = client.put("/user/users/me", json=payload)
+    assert response.status_code == 200
+    assert response.json() == {
+        "user_id": 1,
+        "name": "dave",
+        "phone": "222",
+        "address": "new",
+    }
+    client.app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_update_profile_partial(client_and_repo: tuple[TestClient, DummyUserRepo]) -> None:
+    client, _ = client_and_repo
+    user = DummyUser(1, "erin", "333", "home")
+    client.app.dependency_overrides[get_current_user] = lambda: user
+    payload = {"address": "office"}
+    response = client.put("/user/users/me", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["address"] == "office"
+    assert data["phone"] == "333"
+    client.app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_delete_profile(client_and_repo: tuple[TestClient, DummyUserRepo]) -> None:
+    client, repo = client_and_repo
+    user = DummyUser(1, "frank", "444", "place")
+    client.app.dependency_overrides[get_current_user] = lambda: user
+    response = client.delete("/user/users/me")
+    assert response.status_code == 204
+    assert "frank" not in repo.users
+    client.app.dependency_overrides.pop(get_current_user, None)


### PR DESCRIPTION
## Summary
- expand user router tests for profile update and deletion
- add auth router tests covering login, refresh, and logout flows
- include order router tests for adding, viewing, and removing dishes

## Testing
- `PYTHONPATH=src pytest` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68b7223903cc8326b612723971402683